### PR TITLE
adding plain ruby implementation vs rust version benchmark file

### DIFF
--- a/benchmark-rust-vs-ruby.rb
+++ b/benchmark-rust-vs-ruby.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'benchmark'
+require 'str_metrics'
+
+tests = [
+  %w[München Munich],
+  %w[Berlin Munich],
+  ['Some rather long string', 'Another rather long string']
+]
+long_words_tests = [
+  [
+    'The Jaro–Winkler distance uses a prefix scale p which gives more favourable ratings to strings that match from the beginning for a set prefix length ll ll .', 'Another rather long string'
+  ],
+  [
+    'The Jaro–Winkler distance uses a prefix scale p which gives more favourable ratings to strings that match from the beginning for a set prefix length ll ll .', 'This report shows the user CPU time, system CPU time, the sum of the user and system CPU times, and the elapsed real time. The unit of time is seconds.'
+  ]
+]
+label_width = 'str_metrics, longer words: StrMetrics::JaroWinkler'.length
+
+Benchmark.bm(label_width) do |x|
+  x.report('str_metrics, short words: StrMetrics::JaroWinkler') do
+    50_000.times do
+      tests.each do |words|
+        StrMetrics::JaroWinkler.distance(words[0], words[1])
+      end
+    end
+  end
+  x.report('ruby, short words: DidYouMean::JaroWinkler') do
+    50_000.times do
+      tests.each do |words|
+        DidYouMean::JaroWinkler.distance(words[0], words[1])
+      end
+    end
+  end
+end
+
+Benchmark.bm(label_width) do |x|
+  x.report('str_metrics, longer words: StrMetrics::JaroWinkler') do
+    50_000.times do
+      long_words_tests.each do |words|
+        StrMetrics::JaroWinkler.distance(words[0], words[1])
+      end
+    end
+  end
+  x.report('ruby, longer words: DidYouMean::JaroWinkler') do
+    50_000.times do
+      long_words_tests.each do |words|
+        DidYouMean::JaroWinkler.distance(words[0], words[1])
+      end
+    end
+  end
+end
+
+Benchmark.bm(label_width) do |x|
+  x.report('str_metrics, short words: StrMetrics::Levenshtein') do
+    50_000.times do
+      tests.each do |words|
+        StrMetrics::Levenshtein.distance(words[0], words[1])
+      end
+    end
+  end
+  x.report('ruby, short words: DidYouMean::Levenshtein') do
+    50_000.times do
+      tests.each do |words|
+        DidYouMean::Levenshtein.distance(words[0], words[1])
+      end
+    end
+  end
+end
+
+Benchmark.bm(label_width) do |x|
+  x.report('str_metrics, longer words: StrMetrics::Levenshtein') do
+    50_000.times do
+      long_words_tests.each do |words|
+        StrMetrics::Levenshtein.distance(words[0], words[1])
+      end
+    end
+  end
+  x.report('ruby, longer words:  DidYouMean::Levenshtein') do
+    50_000.times do
+      long_words_tests.each do |words|
+        DidYouMean::Levenshtein.distance(words[0], words[1])
+      end
+    end
+  end
+end


### PR DESCRIPTION
I am currently planing to integrate your string metrics implementation in production. In order to measure the performance of your rust based implementation vs the implementation provided by ruby (used in spellchecking commands) I created a benchmark.

This might be helpful or interesting for you or others to do the test themselves.

On my machine (Intel® Core™ i7-6700K CPU, 64 GB of RAM) I get following results with ruby 2.7.2:



``` console
> ruby benchmark-rust.rb
                                                         user     system      total        real
str_metrics, short words: StrMetrics::JaroWinkler    0.259539   0.000075   0.259614 (  0.259641)
ruby, short words: DidYouMean::JaroWinkler           1.021090   0.000087   1.021177 (  1.021186)
                                                         user     system      total        real
str_metrics, longer words: StrMetrics::JaroWinkler   2.727105   0.000000   2.727105 (  2.727176)
ruby, longer words: DidYouMean::JaroWinkler         73.245469   0.003986  73.249455 ( 73.273634)
                                                         user     system      total        real
str_metrics, short words: StrMetrics::Levenshtein    0.316490   0.000000   0.316490 (  0.316492)
ruby, short words: DidYouMean::Levenshtein           3.521463   0.000000   3.521463 (  3.521572)
                                                         user     system      total        real
str_metrics, longer words: StrMetrics::Levenshtein   5.704095   0.000000   5.704095 (  5.704270)
ruby, longer words:  DidYouMean::Levenshtein       129.663405   0.043990 129.707395 (129.748556)

```

This is quite a difference.